### PR TITLE
ปรับ Gas Limit, Gas Price และการ Estimate Gas

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export const VALIDATOR_WALLETS: Record<string, {name: string, image: string}> = 
 
 If you want to change `gas prices` or `gas limit` You can change it at `javascript-sdk/.../config.ts`
 ```javascript
-export const GAS_LIMIT = "7000000";
+export const GAS_LIMIT_CLAIM = mainnet = "25000000", testnet = "7000000"
 export const GAS_PRICE = "23000000000";
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export const VALIDATOR_WALLETS: Record<string, {name: string, image: string}> = 
 If you want to change `gas prices` or `gas limit` You can change it at `javascript-sdk/.../config.ts`
 ```javascript
 export const GAS_LIMIT_CLAIM = mainnet = "25000000", testnet = "7000000"
+export const GAS_LIMIT_GOVERNANCE = mainnet = "15000000", testnet = "7000000"
 export const GAS_PRICE = "23000000000";
 ```
 

--- a/packages/javascript-sdk/src/config.ts
+++ b/packages/javascript-sdk/src/config.ts
@@ -26,4 +26,5 @@ export interface IConfig {
 }
 
 export const GAS_LIMIT_CLAIM = process.env.REACT_APP_ENVIRONMENT === 'jfintest' ? "7000000" : "25000000"
+export const GAS_LIMIT_GOVERNANCE = process.env.REACT_APP_ENVIRONMENT === 'jfintest' ? "7000000" : "15000000"
 export const GAS_PRICE = "23000000000";

--- a/packages/javascript-sdk/src/config.ts
+++ b/packages/javascript-sdk/src/config.ts
@@ -25,5 +25,5 @@ export interface IConfig {
   deployerProxyAddress: Web3Address;
 }
 
-export const GAS_LIMIT = "7000000";
+export const GAS_LIMIT_CLAIM = process.env.REACT_APP_ENVIRONMENT === 'jfintest' ? "7000000" : "25000000"
 export const GAS_PRICE = "23000000000";

--- a/packages/javascript-sdk/src/governance.ts
+++ b/packages/javascript-sdk/src/governance.ts
@@ -11,7 +11,7 @@ import {PastEventOptions} from "web3-eth-contract";
 import BigNumber from "bignumber.js";
 import {keccak256} from "web3-utils";
 import {sortEventData} from "./utils";
-import { GAS_PRICE } from "./config";
+import { GAS_LIMIT_GOVERNANCE, GAS_PRICE } from "./config";
 
 export class ProposalBuilder {
 
@@ -241,7 +241,11 @@ export class Governance {
     } else {
       data = this.keyProvider.governanceContract!.methods.propose(targets, values, inputs, builder.description).encodeABI();
     }
-    return this.keyProvider.sendTx({to: this.keyProvider.governanceAddress!, data: data});
+    return this.keyProvider.sendTx({
+      to: this.keyProvider.governanceAddress!,
+      data: data, 
+      gasPrice: GAS_PRICE,
+      gasLimit: GAS_LIMIT_GOVERNANCE});
   }
 
   public async voteForProposal(id: string): Promise<IPendingTx> {
@@ -251,6 +255,8 @@ export class Governance {
     return await this.keyProvider.sendTx({
       to: this.keyProvider.governanceAddress!,
       data: data,
+      gasPrice: GAS_PRICE,
+      gasLimit: GAS_LIMIT_GOVERNANCE
     })
   }
 
@@ -261,6 +267,8 @@ export class Governance {
     return await this.keyProvider.sendTx({
       to: this.keyProvider.governanceAddress!,
       data: data,
+      gasPrice: GAS_PRICE,
+      gasLimit: GAS_LIMIT_GOVERNANCE
     })
   }
 
@@ -272,7 +280,8 @@ export class Governance {
     return await this.keyProvider.sendTx({
       to: this.keyProvider.governanceAddress!,
       data: data,
-      gasPrice: GAS_PRICE
+      gasPrice: GAS_PRICE,
+      gasLimit: GAS_LIMIT_GOVERNANCE
     })
   }
 }

--- a/packages/javascript-sdk/src/governance.ts
+++ b/packages/javascript-sdk/src/governance.ts
@@ -11,7 +11,7 @@ import {PastEventOptions} from "web3-eth-contract";
 import BigNumber from "bignumber.js";
 import {keccak256} from "web3-utils";
 import {sortEventData} from "./utils";
-import { GAS_LIMIT, GAS_PRICE } from "./config";
+import { GAS_PRICE } from "./config";
 
 export class ProposalBuilder {
 
@@ -272,7 +272,6 @@ export class Governance {
     return await this.keyProvider.sendTx({
       to: this.keyProvider.governanceAddress!,
       data: data,
-      gasLimit: GAS_LIMIT,
       gasPrice: GAS_PRICE
     })
   }

--- a/packages/javascript-sdk/src/metamask.ts
+++ b/packages/javascript-sdk/src/metamask.ts
@@ -81,28 +81,27 @@ export const sendTransactionAsync = async (
   }
   console.log("Nonce: " + nonce);
   const chainId = await web3.eth.getChainId();
-  const tx = {
+
+
+  // declear gasLimit from parameter or estimate
+  const gasLimit = sendOptions.gasLimit
+    ? numberToHex(sendOptions.gasLimit)
+    : numberToHex(
+        await web3.eth.estimateGas(sendOptions)
+      ); // return units
+
+  // declear transaction payload
+  let tx = {
     from: sendOptions.from,
     to: sendOptions.to,
     value: numberToHex(sendOptions.value || "0"),
-    gas: numberToHex(sendOptions.gasLimit || "1000000"),
-    gasPrice: price,
+    gas: gasLimit, // gas unit (limit)
+    gasPrice: price, // The price of gas for this transaction in wei, defaults to web3.eth.gasPrice.
     data: sendOptions.data,
     nonce: nonce,
     chainId: chainId,
   };
-  const gasEstimation = await web3.eth.estimateGas(tx);
-  console.log(`Gas estimation is: ${gasEstimation}`);
-  if (
-    sendOptions.gasLimit &&
-    Number(gasEstimation) > Number(sendOptions.gasLimit)
-  ) {
-    throw new Error(
-      `Gas estimation exceeds possible limit (${Number(
-        gasEstimation
-      )} > ${Number(sendOptions.gasLimit)})`
-    );
-  }
+
   console.log("Sending transaction via Web3: ", tx);
   return new Promise((resolve, reject) => {
     const promise = web3.eth.sendTransaction(tx);

--- a/packages/javascript-sdk/src/staking.ts
+++ b/packages/javascript-sdk/src/staking.ts
@@ -10,7 +10,7 @@ import {
 import BigNumber from "bignumber.js";
 import {sortEventData, sortHasEventData} from "./utils";
 import {EventData} from "web3-eth-contract";
-import { GAS_LIMIT, GAS_PRICE } from "./config";
+import { GAS_LIMIT_CLAIM, GAS_PRICE } from "./config";
 
 export class Staking {
 
@@ -148,6 +148,7 @@ export class Staking {
       to: this.keyProvider.stakingAddress!,
       value: amount,
       data: data,
+      gasPrice: GAS_PRICE
     })
   }
 
@@ -213,6 +214,7 @@ export class Staking {
     return this.keyProvider.sendTx({
       to: this.keyProvider.stakingAddress!,
       data: data,
+      gasPrice: GAS_PRICE
     })
   }
 
@@ -231,7 +233,7 @@ export class Staking {
     return this.keyProvider.sendTx({
       to: this.keyProvider.stakingAddress!,
       data: data,
-      gasLimit: GAS_LIMIT,
+      gasLimit: GAS_LIMIT_CLAIM,
       gasPrice: GAS_PRICE
     })
   }

--- a/packages/staking-ui/package.json
+++ b/packages/staking-ui/package.json
@@ -69,7 +69,7 @@
     "build:jfintest": "REACT_APP_ENVIRONMENT=jfintest react-scripts build",
     "deploy-preview:mainnet": "yarn build:jfin && firebase deploy --only hosting:mainnet",
     "deploy-preview:testnet": "yarn build:jfintest && firebase deploy --only hosting:testnet",
-    "deploy-preview": "yarn deploy:testnet && yarn deploy:mainnet"
+    "deploy-preview": "yarn deploy-preview:testnet && yarn deploy-preview:mainnet"
   },
   "browserslist": {
     "production": [

--- a/packages/staking-ui/src/components/Modal/content/AddStakingContent.tsx
+++ b/packages/staking-ui/src/components/Modal/content/AddStakingContent.tsx
@@ -32,7 +32,7 @@ const AddStakingContent = observer((props: IAddStakingContent) => {
     if (stakingAmount < 1) return setError("Stake amount must be more 1");
     if (stakingAmount > Number(store.walletBalance) / GWEI)
       return setError(
-        `Stake amount must lower than ${store.getWalletBalance()}`
+        `Insufficient Balance`
       );
 
     modalStore.setIsLoading(true);

--- a/packages/staking-ui/src/components/Modal/content/ClaimStakingContent.tsx
+++ b/packages/staking-ui/src/components/Modal/content/ClaimStakingContent.tsx
@@ -1,4 +1,4 @@
-import { IValidator } from "@ankr.com/bas-javascript-sdk";
+import { GAS_LIMIT_CLAIM, IValidator } from "@ankr.com/bas-javascript-sdk";
 import { LoadingOutlined, WarningOutlined } from "@ant-design/icons";
 import { message } from "antd";
 import BigNumber from "bignumber.js";
@@ -82,7 +82,7 @@ const ClaimStakingContent = observer((props: IClaimStakingContent) => {
           <WarningOutlined />
           If reward you received does not match the reward that the system has
           indicated, This may happen from the gas limit. Please increase the gas
-          limit in wallet (up to 7000000).
+          limit in wallet (up to {GAS_LIMIT_CLAIM}).
         </div>
 
         <button

--- a/packages/staking-ui/src/components/Modal/content/UnStakingContent.tsx
+++ b/packages/staking-ui/src/components/Modal/content/UnStakingContent.tsx
@@ -33,7 +33,7 @@ const UnStakingContent = observer((props: IUnStakingContent) => {
     if (!unStakingAmount) return;
     if (unStakingAmount < 1) return setError("Un-Stake amount must be more 1");
     if (unStakingAmount > Number(stakedAmount))
-      return setError(`Un-Stake amount must be lower than ${stakedAmount}`);
+      return setError(`Un-Stake amount must be lower or equal to ${stakedAmount}`);
 
     modalStore.setIsLoading(true);
     const amount = new BigNumber(unStakingAmount)


### PR DESCRIPTION
Gas Limit
- ในการ Claim Reward ปรับขึ้นเป็น = `25m`
- ในการรัน Governance Create Proposal, Vote, Execute เป็น = `15m`
- นอกนั้นใช้วิธีการ `Estimate Gas` อัตโนมัติ เช่น ตอน `Stake` และ `Unstake`

Gas Price
- ใช้ `23` ทั้งหมด